### PR TITLE
Fixes #30: wrap each iteration in conditional 

### DIFF
--- a/script/Batch Mockup Smart Object Replacement.jsx
+++ b/script/Batch Mockup Smart Object Replacement.jsx
@@ -450,12 +450,17 @@ function replaceLoopOptionsFiller( rawData ) {
   data.doc.input  = rawData.input;
   data.doc.inputFormats = rawData.inputFormats;
   data.doc.inputIndex = 0;
-  
+
   // Input folder path
-  if ( data.doc.input && typeof data.doc.input === 'string' ) data.doc.input = [ data.doc.input ];
-  each( data.doc.input, function( item, index ) {
-    data.doc.input[ index ] = absolutelyRelativePath( data.doc.input[index] ).decoded;
-  });
+  if ( data.doc.input ) {
+    if ( typeof data.doc.input === 'string' ) {
+      data.doc.input = [ data.doc.input ];
+    }
+
+    each( data.doc.input, function( item, index ) {
+      data.doc.input[ index ] = absolutelyRelativePath( data.doc.input[index] ).decoded;
+    });
+  }
   
   docPath = data.doc.path;
   


### PR DESCRIPTION
This PR avoids an "undefined is not an object" error from being thrown.

I tested this using the included "example-1". I deleted the "example-1 (output)" folder and ran the `example-1/Batch replace - example 1.jsx` config through Photoshop. The script stops running and leaves the `assets/Web Showcase Project Presentation/Web-Showcase-Project-Presentation.psd` open in Photoshop. 

I added an `alert( data.doc.input )` to L453 and "undefined" is alerted. The `Batch replace - example 1.jsx` config doesn't include an `input` property at the mockup level, which confirms the alerted "undefined" value. But `each` still tries to iterate over data.doc.input when it's undefined, which causes the error.

I moved the `each` iteration into the conditional check that data.doc.input exists and re-executed the script. The script ran and the "example-1 (output)" folder was recreated and the config script executed successfully. "Batch process done!" was alerted after this PRs change.

Note: this PR differs from my original fix for more clarity. Originally, `|| []` was mentioned as the fix in the issue comments, but looking back it seems like it could cover up other type coercion issues, so I went for brevity instead of a terse fix. Let me know your preference.