### PR TITLE
Allow jpeg quality to be configurable

### DIFF
--- a/script/Batch Mockup Smart Object Replacement.jsx
+++ b/script/Batch Mockup Smart Object Replacement.jsx
@@ -267,7 +267,7 @@ function replaceLoop( data ) {
     var splitfilenamepath = outputFilePath.filename.split("/"); 
     splitfilenamepath.splice(-1); 
     newFolder( outputFilePath.path + splitfilenamepath.join("/") );
-    app.activeDocument.saveAs( new File( outputFilePath.fullpath ), saveOpts()[ data.output.format ](), true, Extension.LOWERCASE);
+    app.activeDocument.saveAs( new File( outputFilePath.fullpath ), saveOpts()[ data.output.format ](data), true, Extension.LOWERCASE);
     
     if ( sourceFilePath === null ) app.activeDocument.activeLayer.visible = item.targetVisibility;
     
@@ -522,7 +522,7 @@ function replaceLoopOptionsFiller( rawData ) {
 
 function saveOpts() {
   return {
-    psd: function() {
+    psd: function(configData) {
       
       var psd_saveOpts = new PhotoshopSaveOptions();
       
@@ -534,7 +534,7 @@ function saveOpts() {
       return psd_saveOpts;
       
     },
-    pdf: function() {
+    pdf: function(configData) {
       
       var presetName = '[High Quality Print]';
       var pdf_SaveOpts = new PDFSaveOptions();
@@ -542,16 +542,16 @@ function saveOpts() {
       return pdf_SaveOpts;
       
     },
-    jpg: function() {
+    jpg: function(configData) {
       
       var jpg_SaveOpts = new JPEGSaveOptions();
       jpg_SaveOpts.matte   = MatteType.WHITE;
-      jpg_SaveOpts.quality = 12;
+      jpg_SaveOpts.quality = configData.output.jpgQuality || 12;
       jpg_SaveOpts.formatOptions.STANDARDBASELINE;
       return jpg_SaveOpts;
       
     },
-    png: function() {
+    png: function(configData) {
       
       var png_SaveOpts = new PNGSaveOptions();
       png_SaveOpts.compression = 9;
@@ -559,7 +559,7 @@ function saveOpts() {
       return png_SaveOpts;
       
     },
-    tif: function() {
+    tif: function(configData) {
       
       var tiff_SaveOpts = new TiffSaveOptions();
       tiff_SaveOpts.alphaChannels      = true;


### PR DESCRIPTION
This opens up the quality parameter to config files for JPEG formats to help with file size. To use, add a `jpgQuality` property to the output config. If it's not set, it will default to the highest quality 12.

```
output: {
  path: '$/_output',
  format: 'jpg',
  jpgQuality: 8, // number between 1 and 12, optional
  zeroPadding: true
  folders: false,
  filename: '@mockup - $',
}
```